### PR TITLE
Update repo link for bug reports

### DIFF
--- a/apps/web/src/lib/components/log-report-dialog.svelte
+++ b/apps/web/src/lib/components/log-report-dialog.svelte
@@ -186,7 +186,7 @@
   <svelte:fragment slot="footer">
     <a
       class={buttonClasses}
-      href="https://github.com/ttu-ttu/ebook-reader"
+      href="https://github.com/kamperemu/ebook-reader"
       target="_blank"
       rel="noreferrer"
     >


### PR DESCRIPTION
This is for the Open Repository button in the popup when you click this button in the top right:

<img width="1215" height="602" alt="image" src="https://github.com/user-attachments/assets/4ca6d5e5-4a9e-4773-a5bb-3f42cfe5951d" />

<img width="1126" height="777" alt="image" src="https://github.com/user-attachments/assets/62e0d001-5d58-4abb-86cf-2343dfdb4622" />

(which probably needs a better way to distinguish the popup from the background for the pure black theme, but that's separate from this)