### PR TITLE
add support for custom sync server

### DIFF
--- a/apps/web/src/lib/components/book-card/book-manager-header.svelte
+++ b/apps/web/src/lib/components/book-card/book-manager-header.svelte
@@ -27,6 +27,7 @@
     fileCountData$,
     fsStorageSource$,
     gDriveStorageSource$,
+    ttsuRemoteStorageSource$,
     isOnline$,
     oneDriveStorageSource$
   } from '$lib/data/store';
@@ -135,6 +136,15 @@
               label: 'Filesystem',
               key: StorageKey.FS,
               requiresConnectivity: false
+            }
+          ]
+        : []),
+      ...(isStorageSourceAvailable(StorageKey.TTSU_REMOTE, $ttsuRemoteStorageSource$, window)
+        ? [
+            {
+              label: 'Ttsu Remote',
+              key: StorageKey.TTSU_REMOTE,
+              requiresConnectivity: true
             }
           ]
         : [])

--- a/apps/web/src/lib/components/book-export/book-export-dialog.svelte
+++ b/apps/web/src/lib/components/book-export/book-export-dialog.svelte
@@ -15,7 +15,8 @@
     gDriveStorageSource$,
     lastExportedTarget$,
     lastExportedTypes$,
-    oneDriveStorageSource$
+    oneDriveStorageSource$,
+    ttsuRemoteStorageSource$
   } from '$lib/data/store';
   import { executeReplicate$ } from '$lib/functions/replication/replication-progress';
   import { createEventDispatcher } from 'svelte';
@@ -28,6 +29,11 @@
   const dispatch = createEventDispatcher<{
     close: void;
   }>();
+
+  console.info(
+    'doing dispact',
+    isStorageSourceAvailable(StorageKey.TTSU_REMOTE, $ttsuRemoteStorageSource$, window)
+  );
 
   $: if (browser) {
     icons = [
@@ -46,6 +52,15 @@
         : []),
       ...(isStorageSourceAvailable(StorageKey.FS, $fsStorageSource$, window)
         ? [{ ...getStorageIconData(StorageKey.FS), source: StorageKey.FS, label: 'Filesystem' }]
+        : []),
+      ...(isStorageSourceAvailable(StorageKey.TTSU_REMOTE, $ttsuRemoteStorageSource$, window)
+        ? [
+            {
+              ...getStorageIconData(StorageKey.TTSU_REMOTE),
+              source: StorageKey.TTSU_REMOTE,
+              label: 'Ttsu Remote'
+            }
+          ]
         : [])
     ].filter((icon) => icon.source !== $storageSource$);
   }

--- a/apps/web/src/lib/components/log-report-dialog.svelte
+++ b/apps/web/src/lib/components/log-report-dialog.svelte
@@ -47,6 +47,7 @@
     showExternalPlaceholder$,
     gDriveStorageSource$,
     oneDriveStorageSource$,
+    ttsuRemoteStorageSource$,
     fsStorageSource$,
     syncTarget$,
     keepLocalStatisticsOnDeletion$,
@@ -144,6 +145,8 @@
             gDriveStorageSource$.getValue() === StorageSourceDefault.GDRIVE_DEFAULT,
           oneDriveStorageSource:
             oneDriveStorageSource$.getValue() === StorageSourceDefault.ONEDRIVE_DEFAULT,
+          ttsuRemoteStorageSource:
+            ttsuRemoteStorageSource$.getValue() === StorageSourceDefault.TTSU_REMOTE_DEFAULT,
           fsStorageSource: !!fsStorageSource$.getValue(),
           syncTarget: !!syncTarget$.getValue(),
           keepLocalStatisticsOnDeletion: keepLocalStatisticsOnDeletion$.getValue(),

--- a/apps/web/src/lib/components/settings/settings-storage-source-list.svelte
+++ b/apps/web/src/lib/components/settings/settings-storage-source-list.svelte
@@ -37,6 +37,7 @@
     gDriveStorageSource$,
     isOnline$,
     oneDriveStorageSource$,
+    ttsuRemoteStorageSource$,
     syncTarget$
   } from '$lib/data/store';
   import { AutoReplicationType } from '$lib/functions/replication/replication-options';
@@ -72,6 +73,9 @@
         break;
       case StorageKey.ONEDRIVE:
         configuredIsSourceDefault = name === $oneDriveStorageSource$;
+        break;
+      case StorageKey.TTSU_REMOTE:
+        configuredIsSourceDefault = name === $ttsuRemoteStorageSource$;
         break;
       case StorageKey.FS:
         configuredIsSourceDefault = name === $fsStorageSource$;
@@ -258,7 +262,12 @@
           {@const storageSourceIsSourceDefault = isStorageSourceDefault(
             storageSource.name,
             storageSource.type,
-            [$gDriveStorageSource$, $oneDriveStorageSource$, $fsStorageSource$]
+            [
+              $gDriveStorageSource$,
+              $oneDriveStorageSource$,
+              $ttsuRemoteStorageSource$,
+              $fsStorageSource$
+            ]
           )}
           <div class="flex flex-col">
             <div class="flex">

--- a/apps/web/src/lib/components/settings/settings-storage-source.svelte
+++ b/apps/web/src/lib/components/settings/settings-storage-source.svelte
@@ -56,7 +56,8 @@
   let storageSourceEncryptionDisabled = configuredEncryptionDisabled || false;
   let storageSourceTypes = [
     { key: StorageKey.GDRIVE, label: 'GDrive' },
-    { key: StorageKey.ONEDRIVE, label: 'OneDrive' }
+    { key: StorageKey.ONEDRIVE, label: 'OneDrive' },
+    { key: StorageKey.TTSU_REMOTE, label: 'RemoteAPI' }
   ];
 
   $: if (browser && 'showDirectoryPicker' in window) {

--- a/apps/web/src/lib/data/storage/handler/gdrive-handler.ts
+++ b/apps/web/src/lib/data/storage/handler/gdrive-handler.ts
@@ -11,6 +11,7 @@ import { BaseStorageHandler, type ExternalFile } from '$lib/data/storage/handler
 import { StorageKey } from '$lib/data/storage/storage-types';
 import { database, gDriveStorageSource$ } from '$lib/data/store';
 import pLimit from 'p-limit';
+import { StorageOAuthManager } from '../storage-oauth-manager';
 
 interface GDriveFile extends ExternalFile {
   thumbnailLink?: string;
@@ -23,7 +24,11 @@ export class GDriveStorageHandler extends ApiStorageHandler {
   private baseUploadApiUrl = 'https://www.googleapis.com/upload/drive/v3/files';
 
   constructor(window: Window) {
-    super(StorageKey.GDRIVE, window, gDriveRefreshEndpoint);
+    super(
+      StorageKey.GDRIVE,
+      window,
+      new StorageOAuthManager(StorageKey.GDRIVE, gDriveRefreshEndpoint)
+    );
   }
 
   setInternalSettings(storageSourceName: string) {

--- a/apps/web/src/lib/data/storage/handler/onedrive-handler.ts
+++ b/apps/web/src/lib/data/storage/handler/onedrive-handler.ts
@@ -11,6 +11,7 @@ import { BaseStorageHandler, type ExternalFile } from '$lib/data/storage/handler
 import { StorageKey } from '$lib/data/storage/storage-types';
 import { database, oneDriveStorageSource$ } from '$lib/data/store';
 import pLimit from 'p-limit';
+import { StorageOAuthManager } from '../storage-oauth-manager';
 
 interface OneDriveFile extends ExternalFile {
   thumbnails?: ExternalThumbnail[];
@@ -54,7 +55,11 @@ export class OneDriveStorageHandler extends ApiStorageHandler {
   private baseEndpoint = 'https://graph.microsoft.com/v1.0/me/drive/items';
 
   constructor(window: Window) {
-    super(StorageKey.ONEDRIVE, window, oneDriveTokenEndpoint);
+    super(
+      StorageKey.ONEDRIVE,
+      window,
+      new StorageOAuthManager(StorageKey.ONEDRIVE, oneDriveTokenEndpoint)
+    );
   }
 
   setInternalSettings(storageSourceName: string) {

--- a/apps/web/src/lib/data/storage/handler/remote-api-handler.ts
+++ b/apps/web/src/lib/data/storage/handler/remote-api-handler.ts
@@ -1,0 +1,286 @@
+/**
+ * @license BSD-3-Clause
+ * Copyright (c) 2026, ッツ Reader Authors
+ * All rights reserved.
+ */
+
+import { BaseStorageHandler, type ExternalFile } from './base-handler';
+import type { BookCardProps } from '$lib/components/book-card/book-card-props';
+import { ApiStorageHandler, type RequestOptions } from './api-handler';
+import { database, ttsuRemoteStorageSource$ } from '$lib/data/store';
+import type { StorageKey } from '../storage-types';
+import { StorageBasicAuthManager } from '../storage-basic-auth-manager';
+
+interface TsuFile {
+  id: string;
+  parent: string;
+  name: string;
+  card: BookCardProps;
+}
+
+export class RemoteApiStorageHandler extends ApiStorageHandler {
+  private serverRoot = 'http://127.0.01:8080';
+
+  constructor(storageType: StorageKey, window: Window) {
+    super(storageType, window, new StorageBasicAuthManager());
+  }
+
+  private reqAny<T>(
+    path: string,
+    options: RequestOptions = {},
+    typeToRetrieve: XMLHttpRequestResponseType = 'json',
+    progressBase?: number
+  ): Promise<T> {
+    return super.request(
+      `${this.serverRoot}/${path}`,
+      options,
+      typeToRetrieve,
+      progressBase
+    ) as Promise<T>;
+  }
+
+  protected setInternalSettings(storageSourceName: string): void {
+    const newStorageSource = storageSourceName || ttsuRemoteStorageSource$.getValue();
+
+    if (newStorageSource !== this.storageSourceName) {
+      this.clearData();
+    }
+
+    this.storageSourceName = newStorageSource;
+  }
+
+  /**
+   * If there is a file/folder with the given name in the given folder, it's ID is gotten.
+   * Otherwise it is created and it's ID is gotten.
+   */
+  protected async ensureTitle(
+    name = BaseStorageHandler.rootName,
+    parent = 'root',
+    readOnly = false
+  ): Promise<string> {
+    if (name === BaseStorageHandler.rootName && this.rootId) {
+      return this.rootId;
+    }
+
+    const externalId = this.titleToId.get(name);
+
+    if (externalId) {
+      return externalId;
+    }
+
+    const titleId = await this.reqAny<{ id: string }>('folder', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        name: name,
+        parent: parent,
+        readOnly: readOnly
+      })
+    });
+
+    if (titleId) {
+      this.titleToId.set(name, titleId.id);
+    }
+
+    if (titleId && name === BaseStorageHandler.rootName) {
+      this.rootId = titleId.id;
+    }
+
+    if (!titleId && name === BaseStorageHandler.rootName) {
+      throw new Error('Root folder not found');
+    }
+
+    return titleId.id;
+  }
+
+  /**
+   * Reads a files data.
+   */
+  protected retrieve(
+    file: TsuFile,
+    typeToRetrieve: XMLHttpRequestResponseType,
+    progressBase?: number
+  ): Promise<any> {
+    return this.reqAny(
+      `file/${file.id}`,
+      {
+        trackDownload: true,
+        method: 'GET'
+      },
+      typeToRetrieve,
+      progressBase
+    );
+  }
+
+  /**
+   * Deletes a file or folder by ID.
+   */
+  protected async executeDelete(id: string): Promise<void> {
+    this.reqAny<void>(`delete/${id}`, {
+      method: 'DELETE'
+    });
+  }
+  /**
+   * Get a list of files and folders in the given folder.
+   */
+  private async list(folderId: string) {
+    return this.reqAny<TsuFile[]>(`list/${folderId}`, {
+      method: 'GET'
+    });
+  }
+
+  /**
+   * Uploads or renames a file.
+   * If an externalFile is given, the remote data is replaced (if data is present), and the file is renamed with the given name.
+   * If there is no externalFile, a new file will be created in the given folder.
+   */
+  protected async upload(
+    folderId: string,
+    name: string,
+    files: ExternalFile[],
+    externalFile: ExternalFile | undefined,
+    data: Blob | string | undefined,
+    rootFilePrefix?: string,
+    progressBase?: number
+  ): Promise<ExternalFile> {
+    const form = new FormData();
+
+    if (externalFile) {
+      form.append('id', externalFile.id);
+    } else {
+      form.append('parent', folderId);
+    }
+
+    form.append('name', name);
+
+    if (data) {
+      if (data instanceof Blob) {
+        form.append('data', data);
+      } else {
+        const blob = new Blob([data], { type: 'text/plain' });
+        form.append('data', blob);
+      }
+    }
+
+    const response = await this.reqAny<TsuFile>(
+      `file`,
+      {
+        method: 'POST',
+        body: form,
+        trackUpload: true
+      },
+      'json',
+      progressBase
+    );
+
+    this.updateAfterUpload(
+      response.id,
+      response.name,
+      files,
+      externalFile,
+      {
+        parents: [folderId]
+      },
+      rootFilePrefix
+    );
+
+    return response;
+  }
+
+  protected async getExternalFiles(remoteTitleId: string): Promise<ExternalFile[]> {
+    if (
+      (!this.cacheStorageData || !this.dataListFetched) &&
+      !this.titleToFiles.has(this.currentContext.title)
+    ) {
+      const externalFiles = await this.list(remoteTitleId);
+      if (externalFiles.length) {
+        await this.setTitleData(this.currentContext.title, externalFiles);
+      }
+    }
+
+    return this.titleToFiles.get(this.currentContext.title) || [];
+  }
+
+  protected async setRootFiles(): Promise<void> {
+    if ((!this.cacheStorageData || !this.rootFileListFetched) && !this.rootFiles.size) {
+      const rootFiles = await this.list(this.rootId);
+
+      for (const rootFile of rootFiles) {
+        this.setRootFile(rootFile.name, rootFile);
+      }
+
+      this.rootFileListFetched = true;
+    }
+  }
+
+  async getBookList(): Promise<BookCardProps[]> {
+    if (!this.dataListFetched) {
+      database.listLoading$.next(true);
+
+      try {
+        await this.ensureTitle();
+
+        const bookFolders = await this.list(this.rootId);
+
+        for (const folder of bookFolders) {
+          const bookFiles = await this.list(folder.id);
+          await this.setTitleData(folder.name, bookFiles);
+        }
+
+        this.dataListFetched = true;
+      } catch (error) {
+        this.clearData();
+        throw error;
+      }
+    }
+
+    return [...this.titleToBookCard.values()];
+  }
+
+  private async setTitleData(title: string, files: TsuFile[]) {
+    if (!files.length) {
+      return;
+    }
+
+    const bookCard: BookCardProps = {
+      id: BaseStorageHandler.getDummyId(),
+      title,
+      imagePath: '',
+      characters: 0,
+      lastBookModified: 0,
+      lastBookOpen: 0,
+      progress: 0,
+      lastBookmarkModified: 0,
+      isPlaceholder: false
+    };
+
+    for (let index = 0, { length } = files; index < length; index += 1) {
+      const file = files[index];
+
+      if (file.name.startsWith('bookdata_')) {
+        const { characters, lastBookModified, lastBookOpen } = BaseStorageHandler.getBookMetadata(
+          file.name
+        );
+
+        bookCard.characters = characters;
+        bookCard.lastBookModified = lastBookModified;
+        bookCard.lastBookOpen = lastBookOpen;
+      } else if (file.name.startsWith('progress_')) {
+        const { progress, lastBookmarkModified } = BaseStorageHandler.getProgressMetadata(
+          file.name
+        );
+
+        bookCard.progress = progress;
+        bookCard.lastBookmarkModified = lastBookmarkModified;
+      } else if (file.name.startsWith('cover_')) {
+        // doing this because we need auth to read from the server
+        bookCard.imagePath = (await this.reqAny(`file/${file.id}`, {}, 'blob')) as Blob;
+      }
+    }
+
+    this.titleToFiles.set(title, files);
+    this.titleToBookCard.set(title, bookCard);
+  }
+}

--- a/apps/web/src/lib/data/storage/storage-auth-manager.ts
+++ b/apps/web/src/lib/data/storage/storage-auth-manager.ts
@@ -1,0 +1,33 @@
+/**
+ * @license BSD-3-Clause
+ * Copyright (c) 2026, ッツ Reader Authors
+ * All rights reserved.
+ */
+
+import type { BooksDbStorageSource } from '../database/books-db/versions/books-db';
+import type { StorageUnlockAction } from './storage-source-manager';
+
+export enum AuthType {
+  OAUTH = 'oauth',
+  BASIC = 'basic'
+}
+
+export interface StorageAuthManager {
+  getAuthType(): AuthType;
+
+  getToken(
+    window: Window,
+    storageSourceName: string,
+    askForStorageUnlock: boolean,
+    authWindow: Window
+  ): Promise<string | undefined>;
+
+  getToken(
+    window: Window,
+    storageSourceName: string,
+    askForStorageUnlock: boolean,
+    authWindow?: Window | null,
+    oldUnlockResult?: StorageUnlockAction,
+    oldStorageSource?: BooksDbStorageSource | undefined
+  ): Promise<string | undefined>;
+}

--- a/apps/web/src/lib/data/storage/storage-basic-auth-manager.ts
+++ b/apps/web/src/lib/data/storage/storage-basic-auth-manager.ts
@@ -1,0 +1,58 @@
+/**
+ * @license BSD-3-Clause
+ * Copyright (c) 2026, ッツ Reader Authors
+ * All rights reserved.
+ */
+
+import { unlockStorageData } from '$lib/data/storage/storage-source-manager';
+import { StorageSourceDefault } from '$lib/data/storage/storage-types';
+import { database } from '$lib/data/store';
+import { AuthType, type StorageAuthManager } from './storage-auth-manager';
+
+export class StorageBasicAuthManager implements StorageAuthManager {
+  getAuthType(): AuthType {
+    return AuthType.BASIC;
+  }
+  async getToken(
+    _window: Window,
+    storageSourceName: string,
+    askForStorageUnlock: boolean,
+    _authWindow: Window
+  ): Promise<string | undefined> {
+    switch (storageSourceName) {
+      case StorageSourceDefault.GDRIVE_DEFAULT:
+        throw new Error('Google Drive does not support basic auth.');
+      case StorageSourceDefault.ONEDRIVE_DEFAULT:
+        throw new Error('One Drive does not support basic auth.');
+      case StorageSourceDefault.TTSU_REMOTE_DEFAULT:
+        break;
+    }
+
+    const db = await database.db;
+    const storageSource = await db.get('storageSource', storageSourceName);
+
+    if (!storageSource) {
+      throw new Error(`No storage source with name ${storageSourceName} found`);
+    }
+
+    const unlockResult = await unlockStorageData(
+      storageSource,
+      'You are trying to access protected data',
+      askForStorageUnlock
+        ? {
+            action: `Enter the correct password for ${storageSourceName} and login to your account if required to proceed`,
+            encryptedData: storageSource.data,
+            forwardSecret: true
+          }
+        : undefined
+    );
+
+    if (!unlockResult) {
+      throw new Error(`Unable to unlock required data`);
+    }
+
+    const token = btoa(`${unlockResult.clientId}:${unlockResult.clientSecret}`);
+
+    return token;
+  }
+}

--- a/apps/web/src/lib/data/storage/storage-handler-factory.ts
+++ b/apps/web/src/lib/data/storage/storage-handler-factory.ts
@@ -14,11 +14,13 @@ import { GDriveStorageHandler } from '$lib/data/storage/handler/gdrive-handler';
 import { MergeMode } from '$lib/data/merge-mode';
 import { OneDriveStorageHandler } from '$lib/data/storage/handler/onedrive-handler';
 import { ReplicationSaveBehavior } from '$lib/functions/replication/replication-options';
+import { RemoteApiStorageHandler } from './handler/remote-api-handler';
 
 let backupStorageHandler: BackupStorageHandler;
 let browserStorageHandler: BrowserStorageHandler;
 let gDriveStorageHandler: GDriveStorageHandler;
 let oneDriveStorageHandler: OneDriveStorageHandler;
+let remoteApiStorageHandler: RemoteApiStorageHandler;
 let fsStorageHandler: FilesystemStorageHandler;
 
 export function getStorageHandler(
@@ -151,6 +153,21 @@ export function getStorageHandler(
       );
 
       return oneDriveStorageHandler;
+    case StorageKey.TTSU_REMOTE:
+      remoteApiStorageHandler =
+        remoteApiStorageHandler || new RemoteApiStorageHandler(StorageKey.TTSU_REMOTE, window);
+      remoteApiStorageHandler.updateSettings(
+        window,
+        isForBrowser,
+        saveBehavior,
+        statisticsMergeMode,
+        readingGoalsMergeMode,
+        cacheStorageData,
+        askForStorageUnlock,
+        storageSourceName
+      );
+
+      return remoteApiStorageHandler;
     case StorageKey.FS:
       fsStorageHandler = fsStorageHandler || new FilesystemStorageHandler(window, StorageKey.FS);
       fsStorageHandler.updateSettings(

--- a/apps/web/src/lib/data/storage/storage-oauth-manager.ts
+++ b/apps/web/src/lib/data/storage/storage-oauth-manager.ts
@@ -30,6 +30,7 @@ import { StorageSourceDefault, StorageKey } from '$lib/data/storage/storage-type
 import { database } from '$lib/data/store';
 import { convertAuthErrorResponse } from '$lib/functions/replication/error-handler';
 import { isMobile } from '$lib/functions/utils';
+import { AuthType, type StorageAuthManager } from './storage-auth-manager';
 
 interface OAuthTokenData {
   accessToken: string;
@@ -40,7 +41,7 @@ interface OAuthTokenData {
 
 export const storageOAuthTokens = new Map<string, OAuthTokenData>();
 
-export class StorageOAuthManager {
+export class StorageOAuthManager implements StorageAuthManager {
   private storageType: StorageKey;
 
   private refreshEndpoint;
@@ -72,6 +73,10 @@ export class StorageOAuthManager {
   constructor(type: StorageKey, refreshEndpoint: string) {
     this.storageType = type;
     this.refreshEndpoint = refreshEndpoint;
+  }
+
+  getAuthType() {
+    return AuthType.OAUTH;
   }
 
   async getToken(

--- a/apps/web/src/lib/data/storage/storage-source-manager.ts
+++ b/apps/web/src/lib/data/storage/storage-source-manager.ts
@@ -9,7 +9,12 @@ import {
   StorageSourceDefault,
   internalStorageSourceName
 } from '$lib/data/storage/storage-types';
-import { fsStorageSource$, gDriveStorageSource$, oneDriveStorageSource$ } from '$lib/data/store';
+import {
+  fsStorageSource$,
+  gDriveStorageSource$,
+  oneDriveStorageSource$,
+  ttsuRemoteStorageSource$
+} from '$lib/data/store';
 
 import type { BooksDbStorageSource } from '$lib/data/database/books-db/versions/books-db';
 import StorageUnlock from '$lib/components/storage-unlock.svelte';
@@ -65,6 +70,7 @@ export function isAppDefault(name: string) {
   return (
     name === StorageSourceDefault.GDRIVE_DEFAULT ||
     name === StorageSourceDefault.ONEDRIVE_DEFAULT ||
+    name === StorageSourceDefault.TTSU_REMOTE_DEFAULT ||
     internalStorageSourceName.has(name)
   );
 }
@@ -76,6 +82,9 @@ export function setStorageSourceDefault(name: string, type: StorageKey) {
       break;
     case StorageKey.ONEDRIVE:
       oneDriveStorageSource$.next(name || StorageSourceDefault.ONEDRIVE_DEFAULT);
+      break;
+    case StorageKey.TTSU_REMOTE:
+      ttsuRemoteStorageSource$.next(name || StorageSourceDefault.TTSU_REMOTE_DEFAULT);
       break;
     case StorageKey.FS:
       fsStorageSource$.next(name);

--- a/apps/web/src/lib/data/storage/storage-types.ts
+++ b/apps/web/src/lib/data/storage/storage-types.ts
@@ -9,7 +9,8 @@ export enum StorageKey {
   BROWSER = 'browser',
   FS = 'fs',
   GDRIVE = 'gdrive',
-  ONEDRIVE = 'onedrive'
+  ONEDRIVE = 'onedrive',
+  TTSU_REMOTE = 'ttsu-remote'
 }
 
 export enum StorageDataType {
@@ -23,7 +24,8 @@ export enum StorageDataType {
 
 export enum StorageSourceDefault {
   GDRIVE_DEFAULT = 'ttu-gdrive-default',
-  ONEDRIVE_DEFAULT = 'ttu-onedrive-default'
+  ONEDRIVE_DEFAULT = 'ttu-onedrive-default',
+  TTSU_REMOTE_DEFAULT = 'ttu-remote-default'
 }
 
 export enum InternalStorageSources {

--- a/apps/web/src/lib/data/storage/storage-view.ts
+++ b/apps/web/src/lib/data/storage/storage-view.ts
@@ -55,6 +55,11 @@ export function isStorageSourceAvailable(
         oneDriveScope;
       break;
 
+    case StorageKey.TTSU_REMOTE:
+      hasValidEnvironment =
+        !!storageSourceManager && storageSourceManager !== StorageSourceDefault.TTSU_REMOTE_DEFAULT;
+      break;
+
     case StorageKey.FS:
       hasValidEnvironment = !!storageSourceManager && 'showDirectoryPicker' in window;
       break;

--- a/apps/web/src/lib/data/store.ts
+++ b/apps/web/src/lib/data/store.ts
@@ -231,6 +231,10 @@ export const oneDriveStorageSource$ = writableStringLocalStorageSubject()(
   'oneDriveStorageSource',
   StorageSourceDefault.ONEDRIVE_DEFAULT
 );
+export const ttsuRemoteStorageSource$ = writableStringLocalStorageSubject()(
+  'ttsuRemoteStorageSource',
+  StorageSourceDefault.TTSU_REMOTE_DEFAULT
+);
 
 export const fsStorageSource$ = writableStringLocalStorageSubject()('fsStorageSource', '');
 
@@ -492,6 +496,7 @@ export const booklistSortOptions$ = writableObjectLocalStorageSubject<Record<str
     [StorageKey.BROWSER]: { property: 'lastBookOpen', direction: SortDirection.DESC },
     [StorageKey.GDRIVE]: { property: 'title', direction: SortDirection.ASC },
     [StorageKey.ONEDRIVE]: { property: 'title', direction: SortDirection.ASC },
+    [StorageKey.TTSU_REMOTE]: { property: 'title', direction: SortDirection.ASC },
     [StorageKey.FS]: { property: 'title', direction: SortDirection.ASC }
   }
 );


### PR DESCRIPTION
This brings all the changes from my [original PR ](https://github.com/ttu-ttu/ebook-reader/pull/480).

I have some more time again, and I've been working on the [sync-server](https://github.com/Minnowo/ttsu-sync-server) side of this.
Everything seems to be working well with these changes still, so I think just some minor cleanup and it will be ready to merge. I want to change up the endpoint naming / how they work to be a bit more clear. And I'd also like to add an OpenAPI spec or something for this, so potentially if anyone else wants to write their own sync server, they just need to follow that. I haven't looked into it fully yet though, just an idea.

Eventually I'd like to build this into https://github.com/arianneorpilla/jidoujisho too (I also have an [open PR](https://github.com/arianneorpilla/jidoujisho/pull/494) there), but I think that's also on a feature freeze.