### PR TITLE
build: set up Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "A revival fork of ttsu reader, an online e-book reader that supports Yomichan";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      version = "2.0.0";
+      makeServer = { defaultPort ? "9010" }: with pkgs; writeShellScriptBin "ebook-reader-server-${version}" ''
+        PORT=''${PORT:=${defaultPort}}
+        if nc -z localhost $PORT >/dev/null 2>&1; then
+          echo "Port $PORT already in use. Trying setting environment variable PORT to different value."
+          exit 1
+        fi
+        echo "Starting web server on port $PORT..."
+        xdg-open http://localhost:$PORT 2>/dev/null || true
+        ${static-web-server}/bin/static-web-server -p $PORT -d ${self.packages.${system}.ebook-reader}
+      '';
+    in {
+      packages.${system} = rec {
+        default = ebook-reader-server;
+        ebook-reader-server = makeServer {};
+        ebook-reader = with pkgs; stdenv.mkDerivation (finalAttrs: {
+          pname = "ebook-reader";
+          inherit version;
+
+          src = ./.;
+
+          nativeBuildInputs = [
+            nodejs
+            pnpmConfigHook
+            pnpm # At least required by pnpmConfigHook, if not other (custom) phases
+          ];
+
+          pnpmDeps = fetchPnpmDeps {
+            inherit (finalAttrs) pname version src;
+            fetcherVersion = 3;
+            hash = "sha256-rgY3T8fdTeJD1p1CBydwL8BnEAg5Nu2O/0S0bBl6WQI=";
+          };
+
+          postInstall = ''
+            pushd apps/web
+            pnpm svelte-kit sync
+            pnpm build
+            cp -r build $out
+            popd
+          '';
+
+          meta = {
+            description = "A revival fork of ttsu reader, an online e-book reader that supports Yomichan";
+            homepage = "https://kamperemu.github.io/ebook-reader/";
+            license = lib.licenses.bsd3;
+          };
+        });
+      };
+      devShells.${system}.default = with pkgs; mkShell {
+        inputsFrom = [ self.packages.${system}.ebook-reader ];
+      };
+    };
+}


### PR DESCRIPTION
(Ported my PR on upstream https://github.com/ttu-ttu/ebook-reader/pull/502 to this fork after seeing [this comment](https://github.com/ttu-ttu/ebook-reader/pull/483#issuecomment-4152857151), is this still the most active fork of ttsu-reader?)

I've set up a Nix flake for this repo to make development and deployment on Nix/NixOS easier.

The flake contains

- a development shell output, so upon entering the repository with direnv all dependencies are automatically pulled in,
- `ebook-reader`, all of the built static files
- and a default output `ebook-reader-server` which bundles the reader with [static-web-server](/static-web-server/static-web-server) for quickly running a server

With this added, all a user needs to do to run the reader on Nix/NixOS systems is type a single command:

```SH
nix run github:kamperemu/ebook-reader
```

It's worth mentioning that this adds a couple things that need to be updated in future updates. The version number on line 14 of flake.nix needs to be bumped, along with the pnpm dependency hash on line 44. I'm not super familiar with GitHub Actions or @renovate-bot but there should be a way to keep that up-to-date as dependencies are bumped.

The outputs are only for x86_64-linux because I don't have an Apple machine to test if my derivations work on macOS.

Cheers!